### PR TITLE
fix -Wunused-result warnings

### DIFF
--- a/src/libzvt/gnome-pty-helper.c
+++ b/src/libzvt/gnome-pty-helper.c
@@ -489,11 +489,11 @@ open_ptys (int utmp, int wtmp, int lastlog)
 	
 	/* drop privileges to the user level */
 #if defined(HAVE_SETEUID)
-	seteuid (pwent->pw_uid);
-	setegid (pwent->pw_gid);
+	(void)!seteuid (pwent->pw_uid);
+	(void)!setegid (pwent->pw_gid);
 #elif defined(HAVE_SETREUID)
-	setreuid (savedUid, pwent->pw_uid);
-	setregid (savedGid, pwent->pw_gid);
+	(void)!setreuid (savedUid, pwent->pw_uid);
+	(void)!setregid (savedGid, pwent->pw_gid);
 #else
 #error "No means to drop privileges! Huge security risk! Won't compile."
 #endif
@@ -502,25 +502,25 @@ open_ptys (int utmp, int wtmp, int lastlog)
 
 	/* Restore saved priveleges to root */
 #ifdef HAVE_SETEUID
-	seteuid (savedUid);
-	setegid (savedGid);
+	(void)!seteuid (savedUid);
+	(void)!setegid (savedGid);
 #elif defined(HAVE_SETREUID)
-	setreuid (pwent->pw_uid, savedUid);
-	setregid (pwent->pw_gid, savedGid);
+	(void)!setreuid (pwent->pw_uid, savedUid);
+	(void)!setregid (pwent->pw_gid, savedGid);
 #else
 #error "No means to raise privileges! Huge security risk! Won't compile."
 #endif
 	/* openpty() failed, reject request */
 	if (status == -1){
 		result = 0;
-		write (STDIN_FILENO, &result, sizeof (result));
+		(void)!write (STDIN_FILENO, &result, sizeof (result));
 		return 0;
 	}
 
 	/* a bit tricky, we re-do the part of the openpty()  */
 	/* that required root priveleges, and, hence, failed */
 	group_info = getgrnam ("tty");
-	fchown (slave_pty, getuid (), group_info ? group_info->gr_gid : -1);
+	(void)!fchown (slave_pty, getuid (), group_info ? group_info->gr_gid : -1);
 	fchmod (slave_pty, S_IRUSR | S_IWUSR | S_IWGRP);
 	/* It's too late to call revoke at this time... */
 	/* revoke(term_name); */

--- a/src/libzvt/subshell.c
+++ b/src/libzvt/subshell.c
@@ -75,7 +75,7 @@ sigchld_handler (int signo)
 		if (waitpid (child->pid, &status, WNOHANG) == child->pid){
 			child->exit_status = status;
 			child->dead = 1;
-			write (child->fd, "D", 1);
+			(void)!write (child->fd, "D", 1);
 			return;
 		}
 	}
@@ -373,7 +373,7 @@ zvt_init_subshell (struct vt_em *vt, char *pty_name, int log)
 	} else {
 		close (slave_pty);
 
-		pipe(p);
+		(void)!pipe(p);
 
 		vt->msgfd = p [0];
 		
@@ -391,7 +391,7 @@ zvt_init_subshell (struct vt_em *vt, char *pty_name, int log)
 		pid = waitpid (vt->childpid, &status, WUNTRACED | WNOHANG);
 		if (pid == vt->childpid && child->pid >= 0){
 			child->pid = 0;
-			write (child->fd, "D", 1);
+			(void)!write (child->fd, "D", 1);
 			return -1;
 		}
 		
@@ -435,8 +435,8 @@ zvt_shutdown_subshell (struct vt_em *vt)
 	/* shutdown pty through helper */
 	if (vt->pty_tag) {
 		op = GNOME_PTY_CLOSE_PTY;
-		write (helper_socket_protocol [0], &op, sizeof (op));
-		write (helper_socket_protocol [0], &vt->pty_tag, sizeof (vt->pty_tag));
+		(void)!write (helper_socket_protocol [0], &op, sizeof (op));
+		(void)!write (helper_socket_protocol [0], &vt->pty_tag, sizeof (vt->pty_tag));
 		vt->pty_tag = NULL;
 	}
 


### PR DESCRIPTION
Add (void)! casts to suppress -Wunused-result warnings.
Is this what is desired, or should I add some checking?
for example:
```
if (seteuid (pwent->pw_uid) < 0) {
    fprintf(stderr, "Could not seteuid\n"):
    exit(1);
}
```